### PR TITLE
Add endpoint for pre-transcribed stories

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -180,3 +180,10 @@ class ClusterSubmission(BaseModel):
         },
         description="A dictionary with page number as keys and url for values",
     )
+
+
+class ScoringRequest(BaseModel):
+    """Model that handles requests to score text that is already transcribed"""
+
+    """A string containing a transcribed story"""
+    transcription: str = Field(..., example="Once upon a time...")

--- a/app/api/scoring.py
+++ b/app/api/scoring.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from dotenv import load_dotenv
+
+from app.utils.complexity.squad_score import squad_score, scaler
+from app.api.models import ScoringRequest
+
+# global variables and services
+router = APIRouter()
+load_dotenv()
+
+
+@router.post("/scoring/text")
+async def submission_text(body: ScoringRequest):
+    """
+    Takes a pre-transcribed text string, then passes the transcription to the 
+    SquadScore method.
+    """
+    # score the transcription using SquadScore algorithm
+    score = await squad_score(body.transcription, scaler)
+
+    # return the complexity score
+    return JSONResponse(
+        status_code=200,
+        content={
+            "complexity": score,
+        },
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 from dotenv import load_dotenv
 
-from app.api import submission, visualization, clustering, db
+from app.api import submission, visualization, clustering, db, scoring
 from app.utils.security.header_checking import get_api_key
 
 app = FastAPI(
@@ -19,6 +19,11 @@ app.include_router(
     submission.router,
     tags=['Submission'],
     dependencies=[Security(get_api_key)],
+)
+app.include_router(
+    scoring.router,
+    tags=['Scoring'],
+    dependencies=[Security(get_api_key)]
 )
 app.include_router(
     visualization.router,


### PR DESCRIPTION
# Description

Adds a new endpoint onto the server application that allows us to use the squad score algorithm on stories that have already been pre-transcribed by iOS (or other sources). This was needed, as the existing scoring endpoint was created for the express purpose of passing s3 URLs with a corresponding checksum and does not allow passing a pre-transcribed text string.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [x] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
